### PR TITLE
Add some additional Perms to commvault Iam user

### DIFF
--- a/AWS/iam-user/commvault-iam-user/policies/commvault-iam-user.json
+++ b/AWS/iam-user/commvault-iam-user/policies/commvault-iam-user.json
@@ -134,7 +134,11 @@
         "kms:ListResourceTags",
         "ebs:ListChangedBlocks",
         "iam:SimulatePrincipalPolicy",
-        "ebs:ListSnapshotBlocks"
+        "ebs:ListSnapshotBlocks",
+        "ebs:GetSnapshotBlock",
+        "iam:SimulatePrincipalPolicy",
+        "ec2:DescribeVpcEndpoints"
+
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
@JWwellcome or @chris-applegate,

I have added three more permissions to the Commvault IAM user as per Oriium request C00075277 - SF - AWS-Drupal-Account - Synthetic full cannot run -     [ ref:_00D20n1km._5004KJEyQq:ref ] from Tom Watts.


Backups run faster with AWS direct read support because you can read data off the EBS snapshots directly without the need to create and attach volumes to the access node.
AWS direct read backups leverage [Amazon EBS direct APIs](https://eur01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fdocs.aws.amazon.com%2Febs%2Flatest%2FAPIReference%2FWelcome.html&data=05%7C01%7Ck.welling%40wellcome.org%7Cb30650339ef54f7e265a08da76d63145%7C3b7a675a1fc84983a100cc52b7647737%7C0%7C0%7C637952959602531833%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=l8deQdcPWEuR%2FsTWM%2BGikVXhoGWiWZ3dpeny1FugAV0%3D&reserved=0).(https://docs.aws.amazon.com/ebs/latest/APIReference/Welcome.html)

This feature provides backup acceleration and reduces cost of backup operations.
Key Benefits
•	Read EBS snapshot blocks (GetSnapshotBlock) without creating or attaching a volume.
•	Back up and restore marketplace volumes.
Supported Configurations
•	Streaming backups
•	Backup copy operations to tape
•	Live browse of Microsoft Windows hosts from a backup copy
•	Live browse of Linux hosts from Amazon EBS snapshots
Required Amazon IAM Permissions
Direct read backups use the EBS service, and requires the following AWS permissions:
•	ebs:GetSnapshotBlock
•	iam:SimulatePrincipalPolicy
•	ec2:DescribeVpcEndpoints

Does this point you in the right direction, if not I'm happy to go back to Commvaut with your question?

Kind Regards, 
Tom Watts