### PR TITLE
SCTASK0036671-qualys-role

### DIFF
--- a/AWS/iam-instance-roles/qualys-iam-role/main.tf
+++ b/AWS/iam-instance-roles/qualys-iam-role/main.tf
@@ -1,0 +1,49 @@
+# IAM Role for Qualys Connector - CHG0034045
+resource "aws_iam_role" "wt-qualys-role" {
+  assume_role_policy   = file("${path.module}/policies/wt-qualys-role.json")
+  description          = "This role provides read only access for Qualys"
+  max_session_duration = 7200
+  name                 = "wt-qualys-role"
+
+  tags = {
+    Name        = "wt-qualys-role"
+    Ansible     = var.Ansible
+    BackUps     = var.BackUps
+    Cost        = var.Cost
+    Department  = var.Department
+    Division    = var.Division
+    Environment = var.Environment
+    Internal    = var.Internal
+    Owner       = var.Owner
+    PatchGroup  = var.PatchGroup
+    Terraform   = var.Terraform
+    Use         = var.Use
+  }
+}
+
+# IAM Policy for Qualys Connector - CHG0034045
+resource "aws_iam_policy" "wt-qualys-policy" {
+  policy      = file("${path.module}/policies/wt-qualys-policy.json")
+  description = "This policy allows access to EC2 for Qualys - read only"
+  name        = "wt-qualys-policy"
+
+  tags = {
+    Name        = "wt-qualys-policy"
+    Ansible     = var.Ansible
+    BackUps     = var.BackUps
+    Cost        = var.Cost
+    Department  = var.Department
+    Division    = var.Division
+    Environment = var.Environment
+    Internal    = var.Internal
+    Owner       = var.Owner
+    PatchGroup  = var.PatchGroup
+    Terraform   = var.Terraform
+    Use         = var.Use
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "wt-qualys-policy-attachment" {
+  policy_arn = aws_iam_policy.wt-qualys-policy.arn
+  role       = aws_iam_role.wt-qualys-role.name
+}

--- a/AWS/iam-instance-roles/qualys-iam-role/outputs.tf
+++ b/AWS/iam-instance-roles/qualys-iam-role/outputs.tf
@@ -1,0 +1,11 @@
+output "wt-qualys-role-arn" {
+  value = aws_iam_role.wt-qualys-role.arn
+}
+
+output "wt-qualys-role-name" {
+  value = aws_iam_role.wt-qualys-role.name
+}
+
+output "wt-qualys-role-description" {
+  value = aws_iam_role.wt-qualys-role.description
+}

--- a/AWS/iam-instance-roles/qualys-iam-role/policies/wt-qualys-policy.json
+++ b/AWS/iam-instance-roles/qualys-iam-role/policies/wt-qualys-policy.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowsToReadEC2Details",
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DescribeInstances",
+            "ec2:DescribeAddresses",
+            "ec2:DescribeImages",
+            "ec2:DescribeRegions",
+            "organizations:list*"
+        ],
+        "Resource" :"*"
+      }
+    ]
+  }

--- a/AWS/iam-instance-roles/qualys-iam-role/policies/wt-qualys-role.json
+++ b/AWS/iam-instance-roles/qualys-iam-role/policies/wt-qualys-role.json
@@ -1,0 +1,18 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowsQualysToAssumeTheRole",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::805950163170:root"
+        },
+        "Action": "sts:AssumeRole",
+        "Condition": {
+          "StringEquals": {
+            "sts:ExternalId": "UK-332144-3928933756001"
+          }
+        }
+      }
+    ]
+  }

--- a/AWS/iam-instance-roles/qualys-iam-role/variables.tf
+++ b/AWS/iam-instance-roles/qualys-iam-role/variables.tf
@@ -1,0 +1,13 @@
+# Tagging variables
+variable "Ansible" {}
+variable "BackUps" {}
+variable "Cost" {}
+variable "Department" {}
+variable "Division" {}
+variable "Environment" {}
+variable "Internal" {}
+variable "Owner" {}
+variable "PatchGroup" {}
+variable "Terraform" {}
+variable "Use" {}
+


### PR DESCRIPTION
## Title
Create Qualys role module

## Implementation date
N/A

## Description
Creating a module for an AWS role for Qualys with permissions to read the EC2 instances details.
The role would be used by all the AWS accounts.

## Justification
Qualys is a suite of vulnerability applications and requires to create an inventory of all the EC2 instances in their account in order to identify security vulnerabilities. By granting Qualys the read-permissions on our EC2 instances, they will be able to retrieve the EC2 details.

The use of the Terraform module is helpful so that the Qualys role can be deployed more easily in each AWS account.

___


## Monday.com / Service Now References

### Monday.com and / or Service Now References
ServiceNow Change ticket: [CHG0034045](https://wellcome.service-now.com/nav_to.do?uri=change_request.do?sys_id=8391d1391be5a910c4d2a860f54bcb6b)

---

## Planning
### Implementation Plan
N/A


### Risk and Impact Analysis
Qualys will be able to read EC2 instances details, as approved in the Change ticket [CHG0034045](https://wellcome.service-now.com/nav_to.do?uri=change_request.do?sys_id=8391d1391be5a910c4d2a860f54bcb6b).

### Back Out Plan
N/A

### Test Plan
N/A

---
## Risk Analysis
### What is the impact to Wellcome if this pull request fails?
- [ ] Legal / Financial / Reputational
- [ ] Moderate widespread disruption
- [x] No Key Systems Affected / Back end systems only

### How many users will the pull request affect?
- [ ] Wellcome Wide (100+ people)
- [x] Department Wide (6-100 people)
- [ ] Team / Individual (1-5 people)

### Will there be a user facing service outage during the pull request implementation?
- [ ] Yes
- [x] No

### Have you carried out this type of pull request before?
- [ ] No, Never done before
- [ ] Yes, there are many steps and multiple teams involved
- [x] Yes, many times and it is documented