### PR TITLE
forgot a name in the policy

### DIFF
--- a/AWS/LM/lm-aws-account-onboarding-role/main.tf
+++ b/AWS/LM/lm-aws-account-onboarding-role/main.tf
@@ -18,6 +18,7 @@ resource "aws_iam_role" "lm-iam-role" {
 resource "aws_iam_policy" "lm-iam-policy" {
   policy      = file("${path.module}/policies/lm-policy.json")
   description = "Policy for LM to Utilise to Onboard the Account"
+  name        = "LM-Account-Onboarding-Role-Policy"
   tags = {
     Name        = "LM-Account-Onboarding-Role-Policy"
     Cost        = var.Cost


### PR DESCRIPTION
Forgot to add a name in for the policy in the module.  Changes nothing just stops it giving it a terraform-00013334343432 or similar name in the Account you deploy the module into.