### PR TITLE
CHG0034960-panorama-role-ext

### DIFF
--- a/AWS/iam-instance-roles/wt-panorama-cross-instance-role/main.tf
+++ b/AWS/iam-instance-roles/wt-panorama-cross-instance-role/main.tf
@@ -1,0 +1,55 @@
+# This cross-account role sets up logging to Cloudwatch for the MSSP and gives read access to EC2/ALB configuration"
+resource "aws_iam_role" "wt-panorama-cross-account-instance-role" {
+  assume_role_policy = file("${path.module}/policies/ec2-trust.json")
+  description        = "IAM Cross Account Instance Role, that sets up Cloudwatch Logging and MSSP and gives read access to EC2/ALB configuration"
+  name               = "WT_Panorama_Cross_Account_Instance_Role"
+  tags = {
+    Name        = "WT_Panorama_Cross_Account_Instance_Role"
+    Cost        = var.Cost
+    Department  = var.Department
+    Division    = var.Division
+    Environment = var.Environment
+    Owner       = var.Owner
+    Terraform   = var.Terraform
+    Use         = var.Use
+  }
+}
+
+resource "aws_iam_instance_profile" "wt-panorama-cross-account-instance-profile" {
+  name = "WT_Panorama_Instance_Role"
+  role = aws_iam_role.wt-panorama-cross-account-instance-role.name
+  tags = {
+    Name        = "WT_Panorama_Cross_Account_Instance_Profile"
+    Cost        = var.Cost
+    Department  = var.Department
+    Division    = var.Division
+    Environment = var.Environment
+    Owner       = var.Owner
+    Terraform   = var.Terraform
+    Use         = var.Use
+  }
+}
+
+# Policy attachment for SSM
+resource "aws_iam_role_policy_attachment" "amazon-ecs-role-for-ssm-attachnment" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  role       = aws_iam_role.wt-panorama-cross-account-instance-role.id
+}
+
+# Policy attachment SSM Instance Core
+resource "aws_iam_role_policy_attachment" "amazon-ssm-managed-instance-core-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.wt-panorama-cross-account-instance-role.id
+}
+
+# Policy attachment for Cloud Watch Logging
+resource "aws_iam_role_policy_attachment" "cloudwatch-agent-server-policy-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.wt-panorama-cross-account-instance-role.id
+}
+
+# Policy attachment to allow reading EC2 instances and ALBs configuration
+resource "aws_iam_role_policy_attachment" "amazon-ec2readonly-policy-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+  role       = aws_iam_role.wt-panorama-cross-account-instance-role.id
+}

--- a/AWS/iam-instance-roles/wt-panorama-cross-instance-role/outputs.tf
+++ b/AWS/iam-instance-roles/wt-panorama-cross-instance-role/outputs.tf
@@ -1,0 +1,11 @@
+output "wt-panorama-instance-role-arn" {
+  value = aws_iam_role.wt-panorama-cross-account-instance-role.arn
+}
+
+output "wt-panorama-instance-role-name" {
+  value = aws_iam_role.wt-panorama-cross-account-instance-role.name
+}
+
+output "wt-panorama-instance-role-description" {
+  value = aws_iam_role.wt-panorama-cross-account-instance-role.description
+}

--- a/AWS/iam-instance-roles/wt-panorama-cross-instance-role/policies/ec2-trust.json
+++ b/AWS/iam-instance-roles/wt-panorama-cross-instance-role/policies/ec2-trust.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "TrustPolicy",
+          "Effect": "Allow",
+          "Action": "sts:AssumeRole",
+          "Principal": {"AWS": "arn:aws:iam::205349831532:role/WT_Panorama_Instance_Role"}
+      }
+  ]
+}

--- a/AWS/iam-instance-roles/wt-panorama-cross-instance-role/variables.tf
+++ b/AWS/iam-instance-roles/wt-panorama-cross-instance-role/variables.tf
@@ -1,0 +1,40 @@
+# Tagging variables
+variable "Cost" {}
+variable "Department" {}
+variable "Division" {}
+variable "Environment" {}
+variable "Monitoring" {}
+variable "Owner" {}
+variable "Terraform" {}
+variable "Use" {}
+
+
+variable "owner" {
+  description = "Owner of the resource"
+  default     = "Cloud Team"
+}
+
+variable "terraform" {
+  description = "How the resource is managed with Terraform"
+  default     = "True"
+}
+
+variable "division" {
+  description = "Operations Division"
+  default     = "Operations"
+}
+
+variable "department" {
+  description = "Department"
+  default     = "NCW"
+}
+
+variable "use-palo" {
+  description = "Use of resource"
+  default     = "Palo Alto Firewall"
+}
+
+variable "cost-a281" {
+  description = "NCW Cost Centre"
+  default     = "A281"
+}

--- a/AWS/iam-instance-roles/wt-panorama-instance-role/main.tf
+++ b/AWS/iam-instance-roles/wt-panorama-instance-role/main.tf
@@ -54,12 +54,7 @@ resource "aws_iam_role_policy_attachment" "amazon-ec2readonly-policy-attachment"
   role       = aws_iam_role.wt-panorama-instance-role.id
 }
 
-# Policy attachment to allow reading EC2 instances and ALBs configuration on all AWS accounts
-resource "aws_iam_role_policy_attachment" "amazon-ec2readonly-policy-attachment" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
-  role       = aws_iam_role.wt-panorama-instance-role.id
-}
-
+# Policy to extend the role to all AWS accounts
 resource "aws_iam_policy" "panorama-role-for-other-accounts-policy" {
   policy      = file("${path.module}/policies/wt-panorama-policy.json")
   description = "This policy allows Panorama instances to assume a role in other AWS accounts"

--- a/AWS/iam-instance-roles/wt-panorama-instance-role/main.tf
+++ b/AWS/iam-instance-roles/wt-panorama-instance-role/main.tf
@@ -53,3 +53,31 @@ resource "aws_iam_role_policy_attachment" "amazon-ec2readonly-policy-attachment"
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
   role       = aws_iam_role.wt-panorama-instance-role.id
 }
+
+# Policy attachment to allow reading EC2 instances and ALBs configuration on all AWS accounts
+resource "aws_iam_role_policy_attachment" "amazon-ec2readonly-policy-attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+  role       = aws_iam_role.wt-panorama-instance-role.id
+}
+
+resource "aws_iam_policy" "panorama-role-for-other-accounts-policy" {
+  policy      = file("${path.module}/policies/wt-panorama-policy.json")
+  description = "This policy allows Panorama instances to assume a role in other AWS accounts"
+  name        = "WT_Panorama-AssumeRole"
+  tags = {
+    Name        = "WT_Panorama-AssumeRole"
+    Owner       = var.owner
+    Terraform   = var.terraform
+    Environment = "All"
+    Cost        = var.cost-a281
+    Division    = var.division
+    Department  = var.department
+    Monitoring  = var.Monitoring
+    Use         = var.use-palo
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "panorama-role-for-other-accounts-policy-attachment" {
+  policy_arn = aws_iam_policy.panorama-role-for-other-accounts-policy.arn
+  role       = aws_iam_role.wt-panorama-instance-role.id
+}

--- a/AWS/iam-instance-roles/wt-panorama-instance-role/policies/wt-panorama-policy.json
+++ b/AWS/iam-instance-roles/wt-panorama-instance-role/policies/wt-panorama-policy.json
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowAssumeRoleInOtherAccounts",
+        "Effect": "Allow",
+        "Action": "sts:AssumeRole",
+        "Resource": [
+            "arn:aws:iam::705284639245:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::066453737909:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::250790015188:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::254378162594:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::393607018753:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::600392747173:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::142276723405:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::205349831532:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::545526813606:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::715154568423:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::267269328833:role/WT_Panorama_Instance_Role",
+            "arn:aws:iam::853012140110:role/WT_Panorama_Instance_Role"
+        ]
+      }
+    ]
+  }

--- a/AWS/iam-instance-roles/wt-panorama-instance-role/variables.tf
+++ b/AWS/iam-instance-roles/wt-panorama-instance-role/variables.tf
@@ -3,7 +3,38 @@ variable "Cost" {}
 variable "Department" {}
 variable "Division" {}
 variable "Environment" {}
+variable "Monitoring" {}
 variable "Owner" {}
 variable "Terraform" {}
 variable "Use" {}
 
+
+variable "owner" {
+  description = "Owner of the resource"
+  default     = "Cloud Team"
+}
+
+variable "terraform" {
+  description = "How the resource is managed with Terraform"
+  default     = "True"
+}
+
+variable "division" {
+  description = "Operations Division"
+  default     = "Operations"
+}
+
+variable "department" {
+  description = "Department"
+  default     = "NCW"
+}
+
+variable "use-palo" {
+  description = "Use of resource"
+  default     = "Palo Alto Firewall"
+}
+
+variable "cost-a281" {
+  description = "NCW Cost Centre (Sam Horsman)"
+  default     = "A281"
+}

--- a/AWS/iam-instance-roles/wt-panorama-instance-role/variables.tf
+++ b/AWS/iam-instance-roles/wt-panorama-instance-role/variables.tf
@@ -35,6 +35,6 @@ variable "use-palo" {
 }
 
 variable "cost-a281" {
-  description = "NCW Cost Centre (Sam Horsman)"
+  description = "NCW Cost Centre"
   default     = "A281"
 }


### PR DESCRIPTION
## Title
Panorama Assume role in other AWS accounts

## Implementation date
N/A

## Description
Two modules:
- One module for extending the Assume Role permission of Panorama instances to cover the other AWS accounts.
- The other module for having a Panorama role in the other AWS accounts and allow the Panorama role (Prod) to assume the current account Panorama role.

## Justification
Required for VM monitoring of all AWS accounts.

___


## MCOM / Service Now References

### MCOM and / or Service Now References
[CHG0034960](https://wellcome.service-now.com/nav_to.do?uri=change_request.do?sys_id=4b0bee451b333150c4d2a860f54bcb99)

---

## Planning
### Implementation Plan
Terraform module to be used in several AWS accounts.

### Risk and Impact Analysis
Panorama instances can assume role in the AWS accounts specified in the policy.

### Back Out Plan
Revert Pull Request and Redeploy

### Test Plan
Check Panorama VM Monitoring.

---
## Risk Analysis
### What is the business criticality of the item to be changed (If in doubt seek advice)
- [ ] Business Continuity Application or Service e.g. Agresso, Funding Platform, Bloomberg
- [ ] Business Essential (departmental system that can be worked around)
- [x] Application level impact (e.g. Upgrade)

### What is the impact to Wellcome if this pull request fails?
- [ ] Legal / Financial / Reputational
- [ ] Moderate widespread disruption
- [x] No key systems affected / Back end systems only

### How many users will the pull request affect?
- [ ] Wellcome Wide (100+ people)
- [ ] Department Wide (6-100 people)
- [x] Team / Individual (1-5 people)

### Will there be a user facing service outage during the pull request implementation?
- [ ] Yes
- [x] No

### Have you carried out this type of pull request before?
- [ ] No, Never done before
- [x] Yes, there are many steps and multiple teams involved
- [ ] Yes, many times and it is documented

### Is this change approved by you line manager?
- [ ] Not line manager approved / aware
- [x] Line manager approved / aware

### Internal stakeholders advised e.g. Service desk?
- [ ] Yes
- [ ] No
- [x] N/A

### Relevant documentation produced / updated / retired? Confluence etc
- [x] Yes
- [ ] No
- [ ] N/A

### Please provide a link to the Documentation
[IAM Instance Roles](https://wellcometrust.atlassian.net/wiki/spaces/INF/pages/916160538/IAM+Instance+Roles)